### PR TITLE
Update engine specification to v0.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM ruby:2.3-alpine
 
-MAINTAINER Michael J. Herold
+LABEL maintainer "Michael J. Herold <michael@michaeljherold.com>"
 
 WORKDIR /usr/src/app
 COPY Gemfile* ./

--- a/engine.json
+++ b/engine.json
@@ -6,6 +6,6 @@
     "email": "michael@michaeljherold.com"
   },
   "languages": ["Haml"],
-  "version": "v0.26.0-2",
-  "spec_version": "0.3.0"
+  "version": "v0.26.0-3",
+  "spec_version": "0.3.1"
 }

--- a/engine.json
+++ b/engine.json
@@ -7,5 +7,5 @@
   },
   "languages": ["Haml"],
   "version": "v0.26.0-2",
-  "spec_version": "0.2.0"
+  "spec_version": "0.3.0"
 }

--- a/lib/cc/engine/severity.rb
+++ b/lib/cc/engine/severity.rb
@@ -9,8 +9,8 @@ module CC
       # @api private
       # @return [Hash]
       HAML_LINT_TO_CODE_CLIMATE = {
-        error: "critical",
-        warning: "normal",
+        error: "minor",
+        warning: "info",
       }.freeze
 
       # Converts the HamlLint severity ontology into the Code Climate one

--- a/spec/cc/engine/issue_spec.rb
+++ b/spec/cc/engine/issue_spec.rb
@@ -24,13 +24,13 @@ RSpec.describe CC::Engine::Issue do
     subject { offense.severity }
 
     context "when it is a warning" do
-      it { is_expected.to eq("normal") }
+      it { is_expected.to eq("info") }
     end
 
     context "when it is an error" do
       let(:severity) { ::HamlLint::Severity.new(:error) }
 
-      it { is_expected.to eq("critical") }
+      it { is_expected.to eq("minor") }
     end
   end
 

--- a/spec/cc/engine/severity_spec.rb
+++ b/spec/cc/engine/severity_spec.rb
@@ -3,11 +3,11 @@ require "cc/engine/severity"
 RSpec.describe CC::Engine::Severity do
   it "maps HamlLint errors to critical" do
     severity = ::HamlLint::Severity.new(:error)
-    expect(described_class.from_haml_lint(severity)).to eq("critical")
+    expect(described_class.from_haml_lint(severity)).to eq("minor")
   end
 
   it "maps HamlLint warnings to normal" do
     severity = ::HamlLint::Severity.new(:warning)
-    expect(described_class.from_haml_lint(severity)).to eq("normal")
+    expect(described_class.from_haml_lint(severity)).to eq("info")
   end
 end


### PR DESCRIPTION
Staying on the current version of the CodeClimate spec seems like a good idea, so this updates the specification to the latest version.