### PR TITLE
Build only the master branch and tags (and PRs)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  - master
+  - /^v\d+\.\d+(?:\.\d+)?(?:-\S*)?$/
 cache: bundler
 language: ruby
 rvm:


### PR DESCRIPTION
This is intended to eliminate the duplicate builds when I push a branch
to the origin repository.